### PR TITLE
Slicing opt immediate

### DIFF
--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/ArrayContentsKey.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/ArrayContentsKey.java
@@ -16,6 +16,9 @@ import com.ibm.wala.classLoader.ArrayClass;
  * A {@link PointerKey} which represents the contents of an array instance.
  */
 public final class ArrayContentsKey extends AbstractFieldPointerKey implements FilteredPointerKey {
+  
+  private Integer hashCode = null;
+  
   public ArrayContentsKey(InstanceKey instance) {
     super(instance);
   }
@@ -32,7 +35,10 @@ public final class ArrayContentsKey extends AbstractFieldPointerKey implements F
 
   @Override
   public int hashCode() {
-    return 1061 * instance.hashCode();
+    if (hashCode == null) {
+      hashCode = 1061 * instance.hashCode();
+    }
+    return hashCode;
   }
 
   @Override

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/HeapStatement.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/HeapStatement.java
@@ -32,6 +32,7 @@ public abstract class HeapStatement extends Statement {
   public final static class HeapParamCaller extends HeapStatement {
     // index into the IR instruction array of the call statements
     private final int callIndex;
+    private Integer hashCode = null;
 
     public HeapParamCaller(CGNode node,int callIndex, PointerKey loc) {
       super(node, loc);
@@ -58,7 +59,10 @@ public abstract class HeapStatement extends Statement {
 
     @Override
     public int hashCode() {
-      return getLocation().hashCode() + 4289 * callIndex + 4133 * getNode().hashCode() + 8831;
+      if (hashCode == null) {
+          hashCode = getLocation().hashCode() + 4289 * callIndex + 4133 * getNode().hashCode() + 8831;
+      }
+      return hashCode;
     }
 
     @Override
@@ -74,6 +78,9 @@ public abstract class HeapStatement extends Statement {
   }
 
   public final static class HeapParamCallee extends HeapStatement {
+      
+    private Integer hashCode = null;
+    
     public HeapParamCallee(CGNode node, PointerKey loc) {
       super(node, loc);
     }
@@ -85,7 +92,10 @@ public abstract class HeapStatement extends Statement {
     
     @Override
     public int hashCode() {
-      return getLocation().hashCode() + 7727 * getNode().hashCode() + 7841;
+      if (hashCode == null) {
+        hashCode = getLocation().hashCode() + 7727 * getNode().hashCode() + 7841;
+      }
+      return hashCode;
     }
 
     @Override
@@ -108,6 +118,7 @@ public abstract class HeapStatement extends Statement {
   public final static class HeapReturnCaller extends HeapStatement {
     // index into the instruction array of the relevant call instruction
     private final int callIndex;
+    private Integer hashCode = null;
 //    private final SSAAbstractInvokeInstruction call;
 
     public HeapReturnCaller(CGNode node, int callIndex, PointerKey loc) {
@@ -135,7 +146,10 @@ public abstract class HeapStatement extends Statement {
 
     @Override
     public int hashCode() {
-      return getLocation().hashCode() + 8887 * callIndex + 8731 * getNode().hashCode() + 7919;
+      if (hashCode == null) {
+        hashCode = getLocation().hashCode() + 8887 * callIndex + 8731 * getNode().hashCode() + 7919;
+      }
+      return hashCode;
     }
 
     @Override
@@ -151,6 +165,9 @@ public abstract class HeapStatement extends Statement {
   }
 
   public final static class HeapReturnCallee extends HeapStatement {
+      
+    private Integer hashCode = null;
+      
     public HeapReturnCallee(CGNode node, PointerKey loc) {
       super(node, loc);
     }
@@ -162,7 +179,10 @@ public abstract class HeapStatement extends Statement {
     
     @Override
     public int hashCode() {
-      return getLocation().hashCode() + 9533 * getNode().hashCode() + 9631;
+      if (hashCode == null) {
+        hashCode = getLocation().hashCode() + 9533 * getNode().hashCode() + 9631;
+      }
+      return hashCode;
     }
 
     @Override

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/PDGIndexedNumberedLabeledGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/PDGIndexedNumberedLabeledGraph.java
@@ -1,0 +1,56 @@
+package com.ibm.wala.ipa.slicer;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
+import com.ibm.wala.util.collections.MapUtil;
+import com.ibm.wala.util.graph.labeled.SlowSparseNumberedLabeledGraph;
+
+/**
+ * This class provides additional functionality to keep track of statements in the PDG:
+ * HeapStatements indexed by PointerKey and non-HeapStatements. These indexes
+ * avoid expensive recomputation of relevant statements in method 
+ * {@link PDG#createHeapDataDependenceEdges(PointerKey) }
+ * 
+ * TODO there may be a better way to integrate this functionality into the inheritance
+ * hierarchy than extending SlowSparseNumberedLabeledGraph.
+ * 
+ * TODO other indexing structures from {@link PDG} could be moved here, for example
+ * {@link PDG#callerParamStatements}.
+ * 
+ */
+public class PDGIndexedNumberedLabeledGraph<T,U> extends SlowSparseNumberedLabeledGraph<T, U> {
+
+  Map<PointerKey,Set<Statement>> heapStatementsByKey;
+  Set<Statement> nonHeapStatements;
+
+  public PDGIndexedNumberedLabeledGraph(U defaultLabel){
+    super(defaultLabel);
+    heapStatementsByKey = new HashMap<PointerKey,Set<Statement>>();
+    nonHeapStatements = new HashSet<Statement>();
+  }
+
+  @Override
+  public void addNode(T n) {
+    if (n instanceof HeapStatement){
+      HeapStatement heapStatement = (HeapStatement) n;
+      PointerKey pk = heapStatement.getLocation();
+      Set<Statement> current = MapUtil.findOrCreateSet(heapStatementsByKey, pk);
+      current.add(heapStatement);
+    }
+    else {
+      nonHeapStatements.add((Statement) n);
+    }
+    getNodeManager().addNode(n);
+  }
+
+  public Set<Statement> getHeapStatementsForLocation(PointerKey pk){
+    return MapUtil.findOrCreateSet(heapStatementsByKey, pk);
+  }
+
+  public Set<Statement> getNonHeapStatements(){
+    return nonHeapStatements; 
+  }
+}

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/ReachabilityFunctions.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/ReachabilityFunctions.java
@@ -22,14 +22,15 @@ import com.ibm.wala.util.intset.SparseIntSet;
  */
 public class ReachabilityFunctions<T> implements IFlowFunctionMap<T> {
 
-
   public final static VectorGenFlowFunction FLOW_REACHES = VectorGenFlowFunction.make(SparseIntSet.singleton(0));
-
+  
+  public final static SparseIntSet emptySet = new SparseIntSet();
+  
   public final static IUnaryFlowFunction KILL_FLOW = new IUnaryFlowFunction() {
     @Override
     public SparseIntSet getTargets(int d1) {
       // kill even the reachability predicate 0.
-      return new SparseIntSet();
+      return emptySet;
     }
     @Override
     public String toString() {

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/SliceFunctions.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/SliceFunctions.java
@@ -20,10 +20,16 @@ import com.ibm.wala.util.debug.Assertions;
  * flow functions for flow-sensitive context-sensitive slicer
  */
 public class SliceFunctions implements IPartiallyBalancedFlowFunctions<Statement> {
+  
+  private ReachabilityFunctions<Statement> reachabilityFunctions;
+  
+  public SliceFunctions(){
+    reachabilityFunctions = ReachabilityFunctions.createReachabilityFunctions();
+  }
 
   @Override
   public IUnaryFlowFunction getCallFlowFunction(Statement src, Statement dest, Statement ret) {
-    return ReachabilityFunctions.createReachabilityFunctions().getCallFlowFunction(src, dest, ret);
+    return reachabilityFunctions.getCallFlowFunction(src, dest, ret);
   }
 
   @Override
@@ -65,21 +71,21 @@ public class SliceFunctions implements IPartiallyBalancedFlowFunctions<Statement
 
   @Override
   public IUnaryFlowFunction getCallToReturnFlowFunction(Statement src, Statement dest) {
-    return ReachabilityFunctions.createReachabilityFunctions().getCallToReturnFlowFunction(src, dest);
+    return reachabilityFunctions.getCallToReturnFlowFunction(src, dest);
   }
 
   @Override
   public IUnaryFlowFunction getNormalFlowFunction(Statement src, Statement dest) {
-    return ReachabilityFunctions.createReachabilityFunctions().getNormalFlowFunction(src, dest);
+    return reachabilityFunctions.getNormalFlowFunction(src, dest);
   }
 
   @Override
   public IFlowFunction getReturnFlowFunction(Statement call, Statement src, Statement dest) {
-    return ReachabilityFunctions.createReachabilityFunctions().getReturnFlowFunction(call, src, dest);
+    return reachabilityFunctions.getReturnFlowFunction(call, src, dest);
   }
 
   public IFlowFunction getReturnFlowFunction(Statement src, Statement dest) {
-    return ReachabilityFunctions.createReachabilityFunctions().getReturnFlowFunction(src, dest);
+    return reachabilityFunctions.getReturnFlowFunction(src, dest);
   }
 
   @Override

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/Slicer.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/Slicer.java
@@ -340,6 +340,8 @@ public class Slicer {
     private final SliceFunctions f;
 
     private final boolean backward;
+    
+    private final TabulationDomain<Object, Statement> domain;
 
     public SliceProblem(Collection<Statement> roots, ISDG sdg, boolean backward) {
       this.roots = roots;
@@ -347,6 +349,7 @@ public class Slicer {
       SDGSupergraph forwards = new SDGSupergraph(sdg, backward);
       this.supergraph = backward ? BackwardsSupergraph.make(forwards) : forwards;
       f = new SliceFunctions();
+      domain = new UnorderedDomain<Object, Statement>();
     }
 
     /*
@@ -355,7 +358,7 @@ public class Slicer {
     @Override
     public TabulationDomain<Object, Statement> getDomain() {
       // a dummy
-      return new UnorderedDomain<Object, Statement>();
+      return domain;
     }
 
     /*


### PR DESCRIPTION
Before I start on the slicing-with-serialization work, I want to merge in some performance optimizations that are likely a) uncontroversial and b) useful even if the serialization line of work does not prove useful.

In addition to the three commits in this branch, I would like to get your opinion on the following two commits which may also be good to include:

https://github.com/GrammaTech/WALA/commit/c9e38a21bd93f3d1ebfdab14d10e7245b35a785b  - this avoids repeated creations of a ReachabilityFunctions object, but I wonder if the inlining I've done breaks abstraction too much. Alternately I could create a single ReachabilityFunctions object in this class and call the get*Function() methods on it.

https://github.com/GrammaTech/WALA/commit/107f2ba8b7fc59bd5e786eefb0028edb1c09eb18  - this avoids the grossly inefficient FilterIterator in line 683 and following; however, I had to add an extra layer in the form of a new class, the PDGNumberedLabeledGraph. This class holds  maps that are basically indexes of all the non-heap statements and heap statements by location. The reason I have a separate class is because all addNode() calls are intercepted here and the indexes are updated in one place only. The alternative is to have the indexes in PDG.java itself, but then I need to add code to update indexes every time an addNode() is called in PDG.java, which is not clean and likely to be error prone.
