### PR TITLE
We do not want to ignore classes in a jar whose file path does not correspond to their package path

### DIFF
--- a/com.ibm.wala.core/src/com/ibm/wala/classLoader/ClassLoaderImpl.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/classLoader/ClassLoaderImpl.java
@@ -270,30 +270,32 @@ public class ClassLoaderImpl implements IClassLoader {
       }
       try {
         TypeName T = TypeName.string2TypeName(className);
-        if (loadedClasses.get(T) != null) {
+        // try to read from memory
+        ShrikeClassReaderHandle reader = entryReader;
+        if (fileContents != null) {
+          final Object contents = fileContents.get(entry.getName());
+          if (contents != null) {
+            // reader that uses the in-memory bytes
+            reader = new ByteArrayReaderHandle(entry, (byte[]) contents);
+          }
+        }
+        ShrikeClass tmpKlass = new ShrikeClass(reader, this, cha);
+        TypeName internalT=tmpKlass.getReference().getName();
+        // if the internal name does not correspond to the path we add a warning but still add the class
+        if (!internalT.equals(T)) {
+          Warnings.add(InvalidClassFile.create(className));
+        }
+        // add the class if it is not present yet
+        if (loadedClasses.get(internalT) != null) {
           Warnings.add(MultipleImplementationsWarning.create(className));
-        } else if (parent != null && parent.lookupClass(T) != null) {
+        } else if (parent != null && parent.lookupClass(internalT) != null) {
           Warnings.add(MultipleImplementationsWarning.create(className));
         } else {
-          // try to read from memory
-          ShrikeClassReaderHandle reader = entryReader;
-          if (fileContents != null) {
-            final Object contents = fileContents.get(entry.getName());
-            if (contents != null) {
-              // reader that uses the in-memory bytes
-              reader = new ByteArrayReaderHandle(entry, (byte[]) contents);
-            }
-          }
-          ShrikeClass tmpKlass = new ShrikeClass(reader, this, cha);
-          if (tmpKlass.getReference().getName().equals(T)) {
-            // always used the reader based on the entry after this point,
-            // so we can null out and re-read class file contents
-            loadedClasses.put(T, new ShrikeClass(entryReader, this, cha));
-            if (DEBUG_LEVEL > 1) {
-              System.err.println("put " + T + " ");
-            }
-          } else {
-            Warnings.add(InvalidClassFile.create(className));
+          // always used the reader based on the entry after this point,
+          // so we can null out and re-read class file contents
+          loadedClasses.put(internalT, new ShrikeClass(entryReader, this, cha));
+          if (DEBUG_LEVEL > 1) {
+            System.err.println("put " + internalT + " ");
           }
         }
       } catch (InvalidClassFileException e) {

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/BasicCallGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/BasicCallGraph.java
@@ -45,7 +45,7 @@ public abstract class BasicCallGraph<T> extends AbstractNumberedGraph<CGNode> im
 
   private static final boolean DEBUG = false;
 
-  private final DelegatingNumberedNodeManager<CGNode> nodeManager = new DelegatingNumberedNodeManager<CGNode>();
+  protected final DelegatingNumberedNodeManager<CGNode> nodeManager = new DelegatingNumberedNodeManager<CGNode>();
 
   /**
    * A fake root node for the graph


### PR DESCRIPTION
 This situation happens in JARs generated for the spring web framework. That results in certain class files being excluded from the class hierarchy. Instead, we consider them but still generate a warning.

For example in class_scheduled from stac engagement 6 we have the application classes in:
`BOOT-INF/classes/`

The class in path:
`BOOT-INF/classes/com/bnn/classScheduler/chromosome/Gene.class`

Has the type:
`com.bnn.classScheduler.chromosome.Gene`

